### PR TITLE
Add script for plotting multiple NGIMS tracks

### DIFF
--- a/ngims.py
+++ b/ngims.py
@@ -232,7 +232,3 @@ def plot_track(data):
 
     pp.savefig('track.png')
 
-
-if __name__ == "__main__":
-    data = readCSN('mvn_ngi_l2_ion-abund-15626_20150417T222107_v08_r01.csv',outbound=True)
-    plot_track(data)

--- a/plot_tracks.py
+++ b/plot_tracks.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+
+"""Plot NGIMS satellite tracks from one or more CSV files."""
+
+import argparse
+import ngims
+from matplotlib import pyplot as pp
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Plot one or more NGIMS satellite tracks"
+    )
+    parser.add_argument("files", nargs="+", help="NGIMS CSV files to plot")
+    args = parser.parse_args()
+
+    data = []
+    for filename in args.files:
+        data += ngims.readCSN(filename, outbound=True)
+
+    ngims.plot_track(data)
+    pp.show()
+
+
+if __name__ == "__main__":
+    main()

--- a/plot_tracks.py
+++ b/plot_tracks.py
@@ -1,26 +1,80 @@
 #!/usr/bin/env python
 
-"""Plot NGIMS satellite tracks from one or more CSV files."""
+"""Plot NGIMS satellite tracks from one or more CSV files.
+
+Points are color-coded by time. For a single file, each point's color
+corresponds to its timestamp. When multiple files are supplied, all points
+from a file share a color based on that file's start time.
+"""
 
 import argparse
 import ngims
+import pandas as pd
 from matplotlib import pyplot as pp
+from matplotlib import cm, colors, dates as mdates
 
 
-def main():
+def main() -> None:
     parser = argparse.ArgumentParser(
-        description="Plot one or more NGIMS satellite tracks"
+        description="Plot one or more NGIMS satellite tracks",
     )
     parser.add_argument("files", nargs="+", help="NGIMS CSV files to plot")
     args = parser.parse_args()
 
-    data = []
+    # Load each file into a DataFrame sorted by time
+    dfs = []
     for filename in args.files:
-        data += ngims.readCSN(filename, outbound=True)
+        data = ngims.readCSN(filename, outbound=True)
+        df = pd.DataFrame(data).sort_values("time")
+        dfs.append(df)
 
-    ngims.plot_track(data)
+    lon_key = "lon" if "lon" in dfs[0].columns else "long"
+
+    fig, axs = pp.subplots(2, 1, figsize=(8, 8), constrained_layout=True)
+    cmap = cm.get_cmap("rainbow_r")
+    locator = mdates.AutoDateLocator()
+    formatter = mdates.ConciseDateFormatter(locator)
+
+    if len(dfs) == 1:
+        df = dfs[0]
+        times = mdates.date2num(df["time"])
+        sc = axs[0].scatter(
+            df[lon_key],
+            df["lat"],
+            c=times,
+            cmap=cmap,
+            s=5,
+        )
+        cbar = fig.colorbar(sc, ax=axs[0], fraction=0.025, pad=0.04)
+        cbar.ax.yaxis.set_major_locator(locator)
+        cbar.ax.yaxis.set_major_formatter(formatter)
+        cbar.set_label("Time (UTC)")
+        axs[1].scatter(df["time"], df["alt"], c=times, cmap=cmap, s=5)
+    else:
+        start_times = [mdates.date2num(df["time"].min()) for df in dfs]
+        norm = colors.Normalize(min(start_times), max(start_times))
+        sm = cm.ScalarMappable(norm=norm, cmap=cmap)
+        for df, tnum in zip(dfs, start_times):
+            color = cmap(norm(tnum))
+            axs[0].plot(df[lon_key], df["lat"], ".", color=color, ms=2)
+            axs[1].plot(df["time"], df["alt"], ".", color=color, ms=2)
+        cbar = fig.colorbar(sm, ax=axs[0], fraction=0.025, pad=0.04)
+        cbar.ax.yaxis.set_major_locator(locator)
+        cbar.ax.yaxis.set_major_formatter(formatter)
+        cbar.set_label("File start time (UTC)")
+
+    axs[0].set_xlabel("Longitude (°)")
+    axs[0].set_ylabel("Latitude (°)")
+    axs[0].set_title("Satellite Location")
+
+    axs[1].set_xlabel("Time")
+    axs[1].set_ylabel("Altitude (km)")
+    axs[1].set_title("Altitude vs Time")
+
+    pp.savefig("track.png")
     pp.show()
 
 
 if __name__ == "__main__":
     main()
+


### PR DESCRIPTION
## Summary
- remove in-module plotting entry point from `ngims.py`
- add `plot_tracks.py` script that loads `ngims` and plots one or more tracks on a shared figure

## Testing
- `python -m py_compile ngims.py plot_tracks.py`


------
https://chatgpt.com/codex/tasks/task_e_68b096251de083288ac218b3b09d44ae